### PR TITLE
Exclude dependabot from linting checks

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -7,6 +7,9 @@ jobs:
 
   yamllint:
     name: runner / yamllint
+    if: |
+      (github.actor!= 'dependabot[bot]') &&
+      (contains(github.head_ref, 'dependabot/github_actions/') == false)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4


### PR DESCRIPTION
[Dependabot doesn't have write permissions][1], so best to just exclude
it from the linting checks - as it will only be updating dependencies
rather than making formatting changes anyway.

[1]: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/