### PR TITLE
Omit checking PR body during commit message checks

### DIFF
--- a/.github/workflows/check-commit-message-pr.yml
+++ b/.github/workflows/check-commit-message-pr.yml
@@ -1,0 +1,24 @@
+---
+name: 'Check commit message style on PRs'
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  check-commit-message-style-pr:
+    if: |
+      (github.actor!= 'dependabot[bot]') &&
+      (contains(github.head_ref, 'dependabot/github_actions/') == false)
+    name: Check commit message style on PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check
+        uses: mristin/opinionated-commit-message@v3.0.0
+        with:
+          allow-one-liners: 'true'
+          # omit PR body as it is not part of our squashed commits
+          skip-body-check: 'true'

--- a/.github/workflows/check-commit-message-push.yml
+++ b/.github/workflows/check-commit-message-push.yml
@@ -1,22 +1,16 @@
 ---
-name: 'Check commit message style'
+name: 'Check commit message style on push'
 on:  # yamllint disable-line rule:truthy
-  pull_request:
-    types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
   push:
     branches-ignore:
       - main
 
 jobs:
-  check-commit-message-style:
+  check-commit-message-style-push:
     if: |
       (github.actor!= 'dependabot[bot]') &&
       (contains(github.head_ref, 'dependabot/github_actions/') == false)
-    name: Check commit message style
+    name: Check commit message style on push
     runs-on: ubuntu-latest
     steps:
       - name: Check


### PR DESCRIPTION
The PR body doesn't form part of the commit, so there is no need to check it.

NB If the commit message checker changes in the future to [check the PR commit messages rather than the PR body][1] then we can reinstate the checks then.

[1]: https://github.com/mristin/opinionated-commit-message/issues/28