### PR TITLE
Ensure required status checks always run

### DIFF
--- a/.github/workflows/check-commit-message-pr.yml
+++ b/.github/workflows/check-commit-message-pr.yml
@@ -10,13 +10,13 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   check-commit-message-style-pr:
-    if: |
-      (github.actor!= 'dependabot[bot]') &&
-      (contains(github.head_ref, 'dependabot/github_actions/') == false)
     name: Check commit message style on PR
     runs-on: ubuntu-latest
     steps:
       - name: Check
+        if: |
+          (github.actor!= 'dependabot[bot]') &&
+          (contains(github.head_ref, 'dependabot/github_actions/') == false)
         uses: mristin/opinionated-commit-message@v3.0.0
         with:
           allow-one-liners: 'true'

--- a/.github/workflows/check-commit-message-push.yml
+++ b/.github/workflows/check-commit-message-push.yml
@@ -7,13 +7,13 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   check-commit-message-style-push:
-    if: |
-      (github.actor!= 'dependabot[bot]') &&
-      (contains(github.head_ref, 'dependabot/github_actions/') == false)
     name: Check commit message style on push
     runs-on: ubuntu-latest
     steps:
       - name: Check
+        if: |
+          (github.actor!= 'dependabot[bot]') &&
+          (contains(github.head_ref, 'dependabot/github_actions/') == false)
         uses: mristin/opinionated-commit-message@v2.2.0
         with:
           allow-one-liners: 'true'


### PR DESCRIPTION
The fix in this commit is to move the conditional skipping into the GitHub Actions step, rather than the entire job.