### PR TITLE
Install Gauge on devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,17 +1,19 @@
 # [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
-ARG VARIANT=3-bullseye
-FROM python:${VARIANT}
+ARG VARIANT=3.10-bullseye
+FROM mcr.microsoft.com/devcontainers/python:${VARIANT}
 
 ARG HADOLINT_VERSION=v2.10.0
 
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
-    && apt-get purge -y imagemagick imagemagick-6-common \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# hadolint ignore=DL4001
+RUN wget -qO /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/download/$HADOLINT_VERSION/hadolint-Linux-x86_64 \
     # install Hadolint to lint this and any other Dockerfiles
-    && wget -qO /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/download/$HADOLINT_VERSION/hadolint-Linux-x86_64 \
-    && chmod +x /usr/local/bin/hadolint
+    && chmod +x /usr/local/bin/hadolint \
+    # Install Gauge
+    && curl -SsL https://downloads.gauge.org/stable | sh \
+    && su vscode -c "gauge install python" \
+    && su vscode -c "gauge install html-report"
 
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
 # COPY requirements.txt /tmp/pip-tmp/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,20 +3,7 @@
         "dockerfile": "./Dockerfile",
         "context": "."
     },
-    "features": {
-        "ghcr.io/devcontainers/features/common-utils:1":{
-            "installZsh": "true",
-            "username": "vscode",
-            "uid": "1000",
-            "gid": "1000",
-            "upgradePackages": "true"
-        },
-        "ghcr.io/devcontainers/features/python:1": "none",
-        "ghcr.io/devcontainers/features/node:1": "none"
-    },
-    "overrideFeatureInstallOrder": [
-        "ghcr.io/devcontainers/features/common-utils"
-    ],
+	
 	// Configure tool-specific properties.
 	"customizations": {
 		// Configure properties specific to VS Code.
@@ -40,7 +27,8 @@
 			"extensions": [
 				"ms-python.python",
 				"ms-python.vscode-pylance",
-				"exiasr.hadolint"
+				"exiasr.hadolint",
+				"getgauge.gauge"
 			]
 		}
 	},


### PR DESCRIPTION
This also required changing the Dockerfile so that it pulls from the Python container, as otherwise the `vscode` user wasn't available to install Gauge under.