### PR TITLE
Add default Gauge python example spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Gauge - metadata dir
+.gauge
+
+# Gauge - log files dir
+logs
+
+# Gauge - reports dir
+reports
+
+# Gauge - python compiled files
+*.pyc
+

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "getgauge.gauge"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "*.spec": "gauge",
+        "*.cpt": "gauge"
+    }
+}

--- a/env/default/default.properties
+++ b/env/default/default.properties
@@ -1,0 +1,25 @@
+# default.properties
+# properties set here will be available to the test execution as environment variables
+
+# sample_key = sample_value
+
+#The path to the gauge reports directory. Should be either relative to the project directory or an absolute path
+gauge_reports_dir = reports
+
+#Set as false if gauge reports should not be overwritten on each execution. A new time-stamped directory will be created on each execution.
+overwrite_reports = true
+
+# Set to false to disable screenshots on failure in reports.
+screenshot_on_failure = true
+
+# The path to the gauge logs directory. Should be either relative to the project directory or an absolute path
+logs_directory = logs
+
+# The path the gauge specifications directory. Takes a comma separated list of specification files/directories.
+gauge_specs_dir = specs
+
+# The default delimiter used read csv files.
+csv_delimiter = ,
+
+# Allows steps to be written in multiline
+allow_multiline_step = false

--- a/env/default/python.properties
+++ b/env/default/python.properties
@@ -1,0 +1,4 @@
+GAUGE_PYTHON_COMMAND = python
+
+# Comma seperated list of dirs. path should be relative to project root.
+STEP_IMPL_DIR = step_impl

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,6 @@
+{
+  "Language": "python",
+  "Plugins": [
+    "html-report"
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+getgauge

--- a/specs/example.spec
+++ b/specs/example.spec
@@ -1,0 +1,33 @@
+# Specification Heading
+
+This is an executable specification file. This file follows markdown syntax.
+Every heading in this file denotes a scenario. Every bulleted point denotes a step.
+
+To execute this specification, run
+
+    gauge run specs
+
+
+* Vowels in English language are "aeiou".
+
+## Vowel counts in single word
+
+tags: single word
+
+* The word "gauge" has "3" vowels.
+
+
+## Vowel counts in multiple word
+
+This is the second scenario in this specification
+
+Here's a step that takes a table
+
+* Almost all words have vowels
+     |Word  |Vowel Count|
+     |------|-----------|
+     |Gauge |3          |
+     |Mingle|2          |
+     |Snap  |1          |
+     |GoCD  |1          |
+     |Rhythm|0          |

--- a/step_impl/step_impl.py
+++ b/step_impl/step_impl.py
@@ -1,0 +1,38 @@
+from getgauge.python import step, before_scenario, Messages
+
+vowels = ["a", "e", "i", "o", "u"]
+
+
+def number_of_vowels(word):
+    return len([elem for elem in list(word) if elem in vowels])
+
+
+# --------------------------
+# Gauge step implementations
+# --------------------------
+
+@step("The word <word> has <number> vowels.")
+def assert_no_of_vowels_in(word, number):
+    assert str(number) == str(number_of_vowels(word))
+
+
+@step("Vowels in English language are <vowels>.")
+def assert_default_vowels(given_vowels):
+    Messages.write_message("Given vowels are {0}".format(given_vowels))
+    assert given_vowels == "".join(vowels)
+
+
+@step("Almost all words have vowels <table>")
+def assert_words_vowel_count(table):
+    actual = [str(number_of_vowels(word)) for word in table.get_column_values_with_name("Word")]
+    expected = [str(count) for count in table.get_column_values_with_name("Vowel Count")]
+    assert expected == actual
+
+
+# ---------------
+# Execution Hooks
+# ---------------
+
+@before_scenario()
+def before_scenario_hook():
+    assert "".join(vowels) == "aeiou"


### PR DESCRIPTION
These files were all generated by running `gauge init python`.