### PR TITLE
Pin dependencies to major versions

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -12,9 +12,9 @@ jobs:
       (contains(github.head_ref, 'dependabot/github_actions/') == false)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.0.2
+      - uses: actions/checkout@v3
       - name: yamllint
-        uses: reviewdog/action-yamllint@v1.6.1
+        uses: reviewdog/action-yamllint@v1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2
       - name: hadolint
-        uses: reviewdog/action-hadolint@v1.33
+        uses: reviewdog/action-hadolint@v1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check


### PR DESCRIPTION
Prior to this we were pinning to the patch version, meaning we were getting many dependabot updates.  Better to pin to the major version as this is not a mission-critical repo.